### PR TITLE
Add streaming heartbeats to prevent Gunicorn timeouts

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app --bind 0.0.0.0:$PORT --workers 2 --worker-class sync --timeout 90 --graceful-timeout 90 --keep-alive 30 --max-requests 100 --max-requests-jitter 10
+web: gunicorn app:app --bind 0.0.0.0:$PORT --workers 2 --worker-class sync --timeout 300 --graceful-timeout 300 --keep-alive 30 --max-requests 100 --max-requests-jitter 10

--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import re
 import json
 from typing import List, Tuple, Dict, Any, Optional
+from queue import Queue, Empty
+from threading import Thread
 from collections import Counter
 from datetime import datetime
 from dataclasses import dataclass
@@ -46,7 +48,7 @@ if OPENAI_API_KEY:
 
     client = OpenAI(
         api_key=OPENAI_API_KEY,
-        timeout=60.0,   # More realistic timeout per request
+        timeout=180.0,  # Allow longer completions before the client aborts
         max_retries=2,
         http_client=custom_http_client
     )
@@ -60,6 +62,8 @@ csv_hash_global = None
 df_global = None
 bladder_keywords_global = None
 renal_keywords_global = None
+
+STREAM_HEARTBEAT_SECONDS = 5.0
 
 # =========================
 # Global Helpers
@@ -1467,31 +1471,31 @@ def extract_author_name_from_query(query: str) -> str:
 def yield_hybrid_stream(prompt: str, section: str):
     """Helper function to yield hybrid streaming events"""
     try:
-        stream = client.chat.completions.create(
+        current_content = ""
+        last_boundary_pos = 0
+
+        for event_type, payload in stream_chat_completion_events(
             model="gpt-5-mini",
             reasoning_effort="minimal",
             verbosity="low",
             messages=[{"role": "user", "content": prompt}],
             max_completion_tokens=2000,
-            stream=True
-        )
-
-        current_content = ""
-        last_boundary_pos = 0
-
-        for chunk in stream:
-            if chunk.choices[0].delta.content is not None:
-                token = chunk.choices[0].delta.content
+        ):
+            if event_type == "token":
+                token = payload
                 current_content += token
 
-                # Stream the token immediately
                 yield sse_event("token", {"text": token, "section": section})
 
-                # Check for NEW paragraph boundaries (double newlines)
                 boundary_pos = current_content.find('\n\n', last_boundary_pos)
                 if boundary_pos != -1:
                     yield sse_event("paragraph_boundary", {"section": section})
                     last_boundary_pos = boundary_pos + 2
+            else:
+                yield sse_event("ping", {
+                    "timestamp": int(time.time()),
+                    "section": section
+                })
 
         # Send completion signal
         yield sse_event("done", {})
@@ -1501,6 +1505,52 @@ def yield_hybrid_stream(prompt: str, section: str):
         import traceback
         traceback.print_exc()
         yield sse_event("error", {"message": f"Streaming error: {str(e)}"})
+
+def stream_chat_completion_events(*, heartbeat_interval: float = STREAM_HEARTBEAT_SECONDS, **create_kwargs):
+    """
+    Yield ('token', text) or ('ping', None) tuples while streaming an OpenAI chat completion.
+    Sends periodic heartbeat events even if the API has not produced tokens yet.
+    """
+    if client is None:
+        raise RuntimeError("OpenAI client not initialized")
+
+    create_kwargs = dict(create_kwargs)
+    create_kwargs["stream"] = True
+
+    queue: Queue[Tuple[str, Any]] = Queue()
+
+    def run_stream():
+        try:
+            stream = client.chat.completions.create(**create_kwargs)
+            for chunk in stream:
+                delta = chunk.choices[0].delta
+                if delta and delta.content:
+                    queue.put(("token", delta.content))
+        except Exception as exc:
+            queue.put(("error", exc))
+        finally:
+            queue.put(("done", None))
+
+    worker = Thread(target=run_stream, daemon=True)
+    worker.start()
+
+    try:
+        while True:
+            try:
+                item_type, payload = queue.get(timeout=heartbeat_interval)
+            except Empty:
+                yield ("ping", None)
+                continue
+
+            if item_type == "token":
+                yield ("token", payload)
+            elif item_type == "error":
+                raise payload
+            elif item_type == "done":
+                break
+    finally:
+        worker.join(timeout=0)
+
 
 def generate_kol_analysis_streaming(
     filtered_df: pd.DataFrame,
@@ -1560,8 +1610,10 @@ Write ONE comprehensive paragraph (4-6 sentences) that covers:
 
 Make it flow naturally as a single, well-structured paragraph without internal breaks."""
 
-        # Stream executive summary tokens in real-time
-        summary_stream = client.chat.completions.create(
+        # Stream executive summary tokens in real-time with heartbeats
+        current_content = ""
+        last_boundary_pos = 0
+        for event_type, payload in stream_chat_completion_events(
             model="gpt-5-mini",
             reasoning_effort="minimal",
             verbosity="low",
@@ -1569,16 +1621,10 @@ Make it flow naturally as a single, well-structured paragraph without internal b
                 {"role": "system", "content": "You are a medical affairs analyst. Provide comprehensive analysis immediately without delay. Start your response right away."},
                 {"role": "user", "content": executive_summary_prompt}
             ],
-            max_completion_tokens=500,  # Increased for executive summary
-            stream=True
-        )
-
-        # Stream tokens and detect paragraph boundaries
-        current_content = ""
-        last_boundary_pos = 0
-        for chunk in summary_stream:
-            if chunk.choices[0].delta.content:
-                token = chunk.choices[0].delta.content
+            max_completion_tokens=500,
+        ):
+            if event_type == "token":
+                token = payload
                 current_content += token
 
                 # Stream the token immediately
@@ -1587,9 +1633,14 @@ Make it flow naturally as a single, well-structured paragraph without internal b
                 # Check for NEW paragraph boundaries (double newlines) after last detected position
                 boundary_pos = current_content.find('\n\n', last_boundary_pos)
                 if boundary_pos != -1:
-                    # Send paragraph boundary signal only once
                     yield sse_event("paragraph_boundary", {"section": "executive_summary"})
-                    last_boundary_pos = boundary_pos + 2  # Move past the boundary
+                    last_boundary_pos = boundary_pos + 2
+            else:
+                # Emit heartbeat while waiting on OpenAI
+                yield sse_event("ping", {
+                    "timestamp": int(time.time()),
+                    "section": "executive_summary"
+                })
 
         # Final boundary for executive summary completion
         yield sse_event("section_boundary", {"section": "executive_summary"})
@@ -1641,7 +1692,9 @@ Write ONE comprehensive paragraph that flows naturally covering all four framewo
 
                     # Stream the analysis token by token
                     print(f"🔧 Prompt length: {len(individual_prompt)} chars")
-                    stream = client.chat.completions.create(
+                    profile_content = ""
+                    token_count = 0
+                    for event_type, payload in stream_chat_completion_events(
                         model="gpt-5-mini",
                         reasoning_effort="minimal",
                         verbosity="low",
@@ -1649,20 +1702,12 @@ Write ONE comprehensive paragraph that flows naturally covering all four framewo
                             {"role": "system", "content": "You are a medical affairs analyst. Provide comprehensive analysis immediately without delay. Start your response right away."},
                             {"role": "user", "content": individual_prompt}
                         ],
-                                    max_completion_tokens=600,  # Increased for more complete responses
-                        stream=True
-                    )
-
-                    profile_content = ""
-                    token_count = 0
-                    last_token_time = time.time()
-
-                    for chunk in stream:
-                        if chunk.choices[0].delta.content is not None:
-                            token = chunk.choices[0].delta.content
+                        max_completion_tokens=600,  # Increased for more complete responses
+                    ):
+                        if event_type == "token":
+                            token = payload
                             profile_content += token
                             token_count += 1
-                            last_token_time = time.time()
 
                             # Stream each token with author context
                             yield sse_event("token", {
@@ -1670,11 +1715,12 @@ Write ONE comprehensive paragraph that flows naturally covering all four framewo
                                 "section": "kol_profile",
                                 "author": author
                             })
-
-                        # Send keep-alive ping every 5 seconds during streaming
-                        elif time.time() - last_token_time > 5:
-                            yield sse_event("ping", {"timestamp": int(time.time())})
-                            last_token_time = time.time()
+                        else:
+                            yield sse_event("ping", {
+                                "timestamp": int(time.time()),
+                                "section": "kol_profile",
+                                "author": author
+                            })
 
                     print(f"🔧 Completed streaming for {author}: {token_count} tokens, {len(profile_content)} chars")
 
@@ -1768,22 +1814,23 @@ Therapeutic Area Filter: {ta_filter}
 Write a comprehensive, natural intelligence report based on this data."""
 
         # Stream the analysis in real-time
-        stream = client.chat.completions.create(
+        for event_type, payload in stream_chat_completion_events(
             model="gpt-5-mini",
             reasoning_effort="minimal",
             verbosity="low",
             messages=[{"role": "user", "content": competitor_prompt}],
             max_completion_tokens=3000,
-            stream=True
-        )
+        ):
+            if event_type == "token":
+                token = payload
 
-        for chunk in stream:
-            if chunk.choices[0].delta.content is not None:
-                token = chunk.choices[0].delta.content
-
-                # Stream each token
                 yield sse_event("token", {
                     "text": token,
+                    "section": "competitor_analysis"
+                })
+            else:
+                yield sse_event("ping", {
+                    "timestamp": int(time.time()),
                     "section": "competitor_analysis"
                 })
 
@@ -1839,22 +1886,23 @@ Therapeutic Area Filter: {ta_filter}
 Write a comprehensive, natural intelligence report based on this data."""
 
         # Stream the analysis in real-time
-        stream = client.chat.completions.create(
+        for event_type, payload in stream_chat_completion_events(
             model="gpt-5-mini",
             reasoning_effort="minimal",
             verbosity="low",
             messages=[{"role": "user", "content": institution_prompt}],
             max_completion_tokens=3000,
-            stream=True
-        )
+        ):
+            if event_type == "token":
+                token = payload
 
-        for chunk in stream:
-            if chunk.choices[0].delta.content is not None:
-                token = chunk.choices[0].delta.content
-
-                # Stream each token
                 yield sse_event("token", {
                     "text": token,
+                    "section": "institution_analysis"
+                })
+            else:
+                yield sse_event("ping", {
+                    "timestamp": int(time.time()),
                     "section": "institution_analysis"
                 })
 
@@ -1910,22 +1958,23 @@ Therapeutic Area Filter: {ta_filter}
 Write a comprehensive, natural intelligence report based on this data."""
 
         # Stream the analysis in real-time
-        stream = client.chat.completions.create(
+        for event_type, payload in stream_chat_completion_events(
             model="gpt-5-mini",
             reasoning_effort="minimal",
             verbosity="low",
             messages=[{"role": "user", "content": insights_prompt}],
             max_completion_tokens=3000,
-            stream=True
-        )
+        ):
+            if event_type == "token":
+                token = payload
 
-        for chunk in stream:
-            if chunk.choices[0].delta.content is not None:
-                token = chunk.choices[0].delta.content
-
-                # Stream each token
                 yield sse_event("token", {
                     "text": token,
+                    "section": "insights_analysis"
+                })
+            else:
+                yield sse_event("ping", {
+                    "timestamp": int(time.time()),
                     "section": "insights_analysis"
                 })
 
@@ -1971,22 +2020,23 @@ Therapeutic Area Filter: {ta_filter}
 Write a comprehensive, natural intelligence report based on this data."""
 
         # Stream the analysis in real-time
-        stream = client.chat.completions.create(
+        for event_type, payload in stream_chat_completion_events(
             model="gpt-5-mini",
             reasoning_effort="minimal",
             verbosity="low",
             messages=[{"role": "user", "content": strategy_prompt}],
             max_completion_tokens=3000,
-            stream=True
-        )
+        ):
+            if event_type == "token":
+                token = payload
 
-        for chunk in stream:
-            if chunk.choices[0].delta.content is not None:
-                token = chunk.choices[0].delta.content
-
-                # Stream each token
                 yield sse_event("token", {
                     "text": token,
+                    "section": "strategy_analysis"
+                })
+            else:
+                yield sse_event("ping", {
+                    "timestamp": int(time.time()),
                     "section": "strategy_analysis"
                 })
 
@@ -2796,8 +2846,8 @@ Provide a comprehensive analysis covering:
 
 Deliver insights in paragraph form, 150-200 words."""
 
-            # Stream the AI response
-            stream = client.chat.completions.create(
+            profile_content = ""
+            for event_type, payload in stream_chat_completion_events(
                 model="gpt-5-mini",
                 reasoning_effort="minimal",
                 verbosity="low",
@@ -2806,15 +2856,13 @@ Deliver insights in paragraph form, 150-200 words."""
                     {"role": "user", "content": individual_prompt}
                 ],
                 max_completion_tokens=300,
-                stream=True
-            )
-
-            profile_content = ""
-            for chunk in stream:
-                if chunk.choices[0].delta.content:
-                    token = chunk.choices[0].delta.content
+            ):
+                if event_type == "token":
+                    token = payload
                     profile_content += token
                     yield sse_event("token", {"token": token})
+                else:
+                    yield sse_event("ping", {"timestamp": int(time.time())})
 
             # Send completion event
             yield sse_event("kol_complete", {
@@ -3267,22 +3315,18 @@ Based on the user's query and the relevant conference data above, provide a comp
 Write a natural, conversational response that directly answers the user's question."""
 
             # Enhanced streaming with paragraph boundary detection
-            stream = client.chat.completions.create(
+            accumulated_content = ""
+            last_boundary_pos = 0
+
+            for event_type, payload in stream_chat_completion_events(
                 model="gpt-5-mini",
                 reasoning_effort="minimal",
                 verbosity="low",
                 messages=[{"role": "user", "content": streaming_prompt}],
-                    max_completion_tokens=2000,
-                stream=True
-            )
-
-            # Track content for paragraph detection
-            accumulated_content = ""
-            last_boundary_pos = 0
-
-            for chunk in stream:
-                if chunk.choices[0].delta.content is not None:
-                    token = chunk.choices[0].delta.content
+                max_completion_tokens=2000,
+            ):
+                if event_type == "token":
+                    token = payload
                     accumulated_content += token
 
                     # Send the token (legacy format for compatibility)
@@ -3291,9 +3335,10 @@ Write a natural, conversational response that directly answers the user's questi
                     # Check for NEW paragraph boundaries
                     boundary_pos = accumulated_content.find('\n\n', last_boundary_pos)
                     if boundary_pos != -1:
-                        # Send a special boundary signal
                         yield f"data: |||PARAGRAPH_BREAK|||\n\n"
                         last_boundary_pos = boundary_pos + 2
+                else:
+                    yield f": heartbeat {int(time.time())}\n\n"
 
             # Send completion signal
             yield "data: [DONE]\n\n"


### PR DESCRIPTION
## Summary
- raise the OpenAI client timeout and Gunicorn worker timeout so longer completions are allowed to finish
- add a reusable queue-based streaming helper that emits heartbeat events and use it across the SSE generators
- update every streaming response (KOL analysis, competitor/institution/insights/strategy playbooks, chat) to forward heartbeat pings while waiting on OpenAI tokens

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d397859df8832b977d8f45aca241c7